### PR TITLE
Fixed URL for zeromq

### DIFF
--- a/src/clj/backtype/storm/crate/zeromq.clj
+++ b/src/clj/backtype/storm/crate/zeromq.clj
@@ -17,7 +17,7 @@
   "The url for downloading zeromq"
   [version]
   (format
-   "http://download.zeromq.org/historic/zeromq-%s.tar.gz"
+   "http://download.zeromq.org/zeromq-%s.tar.gz"
    version))
 
 (defn install


### PR DESCRIPTION
Since http://download.zeromq.org/historic/zeromq-2.1.4.tar.gz is now returning a 404, I think we need to use http://download.zeromq.org/zeromq-2.1.4.tar.gz instead.
