### PR TITLE
Demontunes IP API down. 

### DIFF
--- a/src/clj/backtype/storm/security.clj
+++ b/src/clj/backtype/storm/security.clj
@@ -93,7 +93,7 @@
 (def my-ip
   (memoize
     (fn []
-      (let [is (DataInputStream. (.openStream (URL. "http://demontunes.com/api/?g=ip")))
+      (let [is (DataInputStream. (.openStream (URL. "http://whatismyip.akamai.com/")))
             ret (.readLine is)]
         (.close is)
         ret


### PR DESCRIPTION
The demontunes IP api is down as of this writing (see the discussion [here](https://groups.google.com/d/topic/storm-user/Oloin4BBfsE/discussion)). This causes the storm-deploy script to blow up like this:

``` console
Exception in thread "main" java.io.FileNotFoundException: http://demontunes.com/api/?g=ip (NO_SOURCE_FILE:1)
    at clojure.lang.Compiler.eval(Compiler.java:5440)
    at clojure.lang.Compiler.eval(Compiler.java:5415)
    at clojure.lang.Compiler.eval(Compiler.java:5391)
    at clojure.core$eval.invoke(core.clj:2382)
    at clojure.main$eval_opt.invoke(main.clj:235)
    at clojure.main$initialize.invoke(main.clj:254)
    at clojure.main$null_opt.invoke(main.clj:279)
    at clojure.main$main.doInvoke(main.clj:354)
    at clojure.lang.RestFn.invoke(RestFn.java:422)
    at clojure.lang.Var.invoke(Var.java:369)
    at clojure.lang.AFn.applyToHelper(AFn.java:165)
    at clojure.lang.Var.applyTo(Var.java:482)
    at clojure.main.main(main.java:37)
Caused by: java.io.FileNotFoundException: http://demontunes.com/api/?g=ip
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1434)
    at java.net.URL.openStream(URL.java:1010)
    at backtype.storm.security$fn__2947.invoke(security.clj:96)
    at clojure.lang.AFn.applyToHelper(AFn.java:159)
    at clojure.lang.AFn.applyTo(AFn.java:151)
    at clojure.core$apply.invoke(core.clj:540)
    at clojure.core$memoize$fn__4542.doInvoke(core.clj:5093)
    at clojure.lang.RestFn.invoke(RestFn.java:398)
    at backtype.storm.security$authorizeme.invoke(security.clj:104)
    at backtype.storm.provision$attach_BANG_.invoke(provision.clj:55)
    at backtype.storm.provision$start_with_nodes_BANG_.invoke(provision.clj:79)
    at backtype.storm.provision$start_BANG_.invoke(provision.clj:85)
    at backtype.storm.provision$_main.doInvoke(provision.clj:136)
    at clojure.lang.RestFn.invoke(RestFn.java:483)
    at clojure.lang.Var.invoke(Var.java:381)
    at user$eval8525.invoke(NO_SOURCE_FILE:1)
    at clojure.lang.Compiler.eval(Compiler.java:5424)
    ... 12 more
```

I changed that line to use http://whatismyip.akamai.com/ instead, and it seems to work. I don't know if that is the approach you would like to take, Nathan. I'll attach my change so you can make a decision. 
