### PR TITLE
Fixed two SEVERE bugs (build breakers in fact) in the storm build portion of deploy script

### DIFF
--- a/src/clj/backtype/storm/crate/storm.clj
+++ b/src/clj/backtype/storm/crate/storm.clj
@@ -55,31 +55,28 @@
    ))
 
 (defn get-release [request release]
-  (def url "git://github.com/nathanmarz/storm.git")
+  (let [url "git://github.com/nathanmarz/storm.git"
+       rl (if (empty? release) "" release)] ; empty string for pallet
 
-  ; Set release to empty string if nil so that pallet will parse it properly
-  (if (empty? release)
-    (def release "")
-  )
+    (-> request
+      (exec-script/exec-checked-script
+        "Build storm"
+        (cd "$HOME")
+        (mkdir -p "build")
+        (cd "$HOME/build")
 
-  (-> request
-    (exec-script/exec-checked-script
-      "Build storm"
-      (cd "$HOME")
-      (mkdir -p "build")
-      (cd "$HOME/build")
-
-      (when-not (directory? "storm")
-        (if (not (empty? ~release)) ; Check for release, use branch if present
-          (git clone -b ~release ~url)
-          (git clone ~url) ; Default to master branch
+        (when-not (directory? "storm")
+          (if (not (empty? ~rl)) ; Check for release, use branch if present
+            (git clone -b ~rl ~url)
+            (git clone ~url) ; Default to master branch
+          )
         )
-      )
 
-      (cd storm)
-      (git pull)
-      (bash "bin/build_release.sh")
-      (cp "*.zip $HOME/")
+        (cd storm)
+        (git pull)
+        (bash "bin/build_release.sh")
+        (cp "*.zip $HOME/")
+      )
     )
   )
 )

--- a/src/clj/backtype/storm/crate/storm.clj
+++ b/src/clj/backtype/storm/crate/storm.clj
@@ -55,24 +55,34 @@
    ))
 
 (defn get-release [request release]
+  (def url "git://github.com/nathanmarz/storm.git")
+
+  ; Set release to empty string if nil so that pallet will parse it properly
+  (if (empty? release)
+    (def release "")
+  )
+
   (-> request
     (exec-script/exec-checked-script
       "Build storm"
-
       (cd "$HOME")
       (mkdir -p "build")
       (cd "$HOME/build")
+
       (when-not (directory? "storm")
-        (if ~release
-          (git clone -b ~release "git://github.com/nathanmarz/storm.git")
-          (git clone "git://github.com/nathanmarz/storm.git")))
+        (if (not (empty? ~release)) ; Check for release, use branch if present
+          (git clone -b ~release ~url)
+          (git clone ~url) ; Default to master branch
+        )
+      )
 
       (cd storm)
       (git pull)
-      (sh "bin/build_release.sh")
+      (bash "bin/build_release.sh")
       (cp "*.zip $HOME/")
-      )
-    ))
+    )
+  )
+)
 
 (defn make [request release]
   (->


### PR DESCRIPTION
NOTE: The current version of storm-deploy is currently BROKEN by the bugs for which fixes this pull request contains. 

To be clear, the current version of storm-deploy must not have been tested because the following two issues are currently on the master branch and should affect ANY environment:

1) The pallet code that executes the call to the build_release.sh script utilizes the (sh) function which obviously will not work because BASH is required to execute Storm's build_release script.

2) The (get-release) function does not properly build the BASH conditional which checks for the release version specified on the CLI and simply ignores it even if it is present, resulting in an automatic install attempt of whatever is on the master branch of the Storm repo. This is obviously bad news since the bleeding edge is usually not desired in production.

I have included fixes for both of these issues and thoroughly tested them from a completely scratch deployment. I urge this request to be merged in as quickly as possible since I cannot see the current version working under any circumstances.
