### PR TITLE
Fixed IP Address Output to properly list all the IPs for the various nodes

### DIFF
--- a/src/clj/backtype/storm/crate/storm.clj
+++ b/src/clj/backtype/storm/crate/storm.clj
@@ -66,20 +66,14 @@
         (cd "$HOME/build")
 
         (when-not (directory? "storm")
-          (if (not (empty? ~rl)) ; Check for release, use branch if present
+          (if (not (empty? ~rl))
             (git clone -b ~rl ~url)
-            (git clone ~url) ; Default to master branch
-          )
-        )
+            (git clone ~url)))
 
         (cd storm)
         (git pull)
         (bash "bin/build_release.sh")
-        (cp "*.zip $HOME/")
-      )
-    )
-  )
-)
+        (cp "*.zip $HOME/")))))
 
 (defn make [request release]
   (->

--- a/src/clj/backtype/storm/provision.clj
+++ b/src/clj/backtype/storm/provision.clj
@@ -31,8 +31,8 @@
 (defn- print-ips-for-tag! [aws tag-str]
   (let [running-node (filter running? (map (partial pallet.compute.jclouds/jclouds-node->node aws) (nodes-in-group aws tag-str)))]
     (info (str "TAG:     " tag-str))
-    (info (str "PUBLIC:  " (map primary-ip running-node)))
-    (info (str "PRIVATE: " (map private-ip running-node)))))
+    (info (str "PUBLIC:  " (clojure.string/join ", " (map primary-ip running-node))))
+    (info (str "PRIVATE: " (clojure.string/join ", " (map private-ip running-node))))))
 
 (defn print-all-ips! [aws name]
   (let [all-tags [(str "zookeeper-" name) (str "nimbus-" name) (str "supervisor-" name)]]


### PR DESCRIPTION
tl;dr Fix for issue #21.

For some reason the listing code was not joining the items inside of the LazySeq returned by the map function being used to gather the primary and private IPs for the nodes.

Adding in the join call on the resulting LazySeq produces a comma-separated list of IPs for convenient summary during deploy and on-demand with lein run :deploy --ips

This merge also contains some random parenthetical cleanup from a previous commit.

Fully tested and working.
