### PR TITLE
Fix AWS error: InvalidPlacementGroup.Unknown

### DIFF
--- a/src/clj/backtype/storm/security.clj
+++ b/src/clj/backtype/storm/security.clj
@@ -116,7 +116,7 @@
         (sg-service compute)
         region
         to-group
-        (UserIdGroupPair. user-id from-group)
+        (UserIdGroupPair. "" from-group)
         )
     (catch IllegalStateException _)
     )))


### PR DESCRIPTION
AWS's call to AuthorizeSecurityGroupIngress doesn't
like being called specifying the same UserID as the
current user.
