### PR TITLE
Ganglia UI missing mod_php in apache

### DIFF
--- a/src/clj/backtype/storm/crate/ganglia.clj
+++ b/src/clj/backtype/storm/crate/ganglia.clj
@@ -17,7 +17,7 @@
   [session]
   (-> session
       (package/packages
-       :aptitude ["rrdtool" "librrds-perl" "librrd-dev" "php5-gd"
+       :aptitude ["rrdtool" "librrds-perl" "librrd-dev" "php5-gd" "libapache2-mod-php5"
                   "ganglia-monitor" "ganglia-webfrontend" "gmetad"])
       (file/symbolic-link
        "/usr/share/ganglia-webfrontend" "/var/www/ganglia")))


### PR DESCRIPTION
Add the libapache2-mod-php5 package to
fix missing php handler in apache
