### PR TITLE
Adding ec2 availability zone location parameter to cluster yaml config

### DIFF
--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -149,7 +149,11 @@
                    (assoc-with-conf-key :image-id "image")
                    (assoc-with-conf-key :hardware-id "hardware")
                    (assoc-with-conf-key :spot-price "spot.price" :f float)
-                   ))))
+                   )
+        :location (-> {}
+                      (assoc-with-conf-key :location-id "location"))
+        )))
+
 
 (defn zookeeper
   ([name server-spec]


### PR DESCRIPTION
This adds an option, to the cluster.yaml config file, to allow you to specify the AWS availability zone for each node type.

``` yaml
# clusters.yaml
nimbus.image: "us-east-1/ami-d726abbe"
nimbus.hardware: "m1.large"
nimbus.location: "us-east-1c"
```
