### PR TITLE
Add splunk support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [storm "0.5.4"]
                  [commons-codec "1.4"]
                  [org.cloudhoist/pallet "0.7.2"]
+                 [org.cloudhoist/splunk "0.7.0-SNAPSHOT"]
                  [org.cloudhoist/pallet-jclouds "1.4.2"]
                  [org.cloudhoist/java "0.5.0"]
                  [org.cloudhoist/git "0.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [storm "0.5.4"]
                  [commons-codec "1.4"]
                  [org.cloudhoist/pallet "0.7.2"]
-                 [org.cloudhoist/splunk "0.7.0-SNAPSHOT"]
+                 [org.cloudhoist/splunk "0.7.0-alpha.1"]
                  [org.cloudhoist/pallet-jclouds "1.4.2"]
                  [org.cloudhoist/java "0.5.0"]
                  [org.cloudhoist/git "0.5.0"]

--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -96,7 +96,11 @@
                                (if (.exists (java-utils/file "conf/credentials.spl"))
                                    (splunk/splunk session
                                                   :forwarder true
-                                                  :inputs {"monitor:///home/storm/storm/logs/*" {}}
+                                                  :inputs {"monitor:///home/storm/storm/logs/worker*.log" {:sourcetype "worker"}
+                                                           "monitor:///home/storm/storm/logs/supervisor*.log" {:sourcetype "supervisor"}
+                                                           "monitor:///home/storm/storm/logs/nimbus*.log" {:sourcetype "nimbus"}
+                                                           "monitor:///home/storm/storm/logs/drpc*.log" {:sourcetype "drpc"}
+                                                           "monitor:///home/storm/storm/logs/ui*.log" {:sourcetype "ui"} }
                                                   :credentials "conf/credentials.spl")
                                    session))))
                :exec (phase-fn


### PR DESCRIPTION
This commit adds support for automatically setting up hosted splunk-storm support on a storm cluster using the latest version of the splunk crate, 0.7.0.alpha.1. Splunk setup code is only executed if a credentials.spl file is present in the conf directory.
