### PR TITLE
Add storm log properties config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ logs/
 *.jar
 pom.xml
 .lein-deps-sum
+*~
+*.swp

--- a/conf/storm.log.properties
+++ b/conf/storm.log.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=INFO, A1
+
+log4j.appender.A1 = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.A1.File = ${storm.home}/logs/${logfile.name}
+log4j.appender.A1.Append = true
+log4j.appender.A1.DatePattern = '.'yyy-MM-dd
+log4j.appender.A1.layout = org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n

--- a/src/clj/backtype/storm/crate/storm.clj
+++ b/src/clj/backtype/storm/crate/storm.clj
@@ -222,3 +222,9 @@
            :content (mk-storm-yaml name local-storm-file (:compute request))
            :overwrite-changes true)))
 
+(defn write-storm-log-properties [request local-storm-log-properties-file]
+      (-> request
+          (remote-file/remote-file
+           "$HOME/storm/log4j/storm.log.properties"
+           :local-file local-storm-log-properties-file
+           :overwrite-changes true)))

--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -45,6 +45,10 @@
   (.getPath (ClassLoader/getSystemResource "storm.yaml"))
   )
 
+(def storm-log-properties-path
+  (.getPath (ClassLoader/getSystemResource "storm.log.properties"))
+  )
+
 (def storm-conf (read-storm-config))
 
 (defn nimbus-name [name]
@@ -100,7 +104,9 @@
                            (ganglia/ganglia-node (nimbus-name name))
                            (storm/install-supervisor
                             release
-                            "/mnt/storm"))
+                            "/mnt/storm")
+                           (storm/write-storm-log-properties 
+                            storm-log-properties-path))
                :post-configure (phase-fn
                                 (ganglia/ganglia-finish)
                                 (storm/write-storm-exec
@@ -126,6 +132,8 @@
                            (storm/install-nimbus
                             release
                             "/mnt/storm")
+                           (storm/write-storm-log-properties 
+                            storm-log-properties-path)
                            (storm/install-ui)
                            (maybe-install-drpc release))
                :post-configure (phase-fn


### PR DESCRIPTION
This overwrites the storm/log4j/storm.log.properties file with a version you put in the storm-deploy conf directory rather than being stuck with whatever is default in the storm release. Includes the same storm.log.properties file as storm 0.8.2.
