### PR TITLE
Add newrelic crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 lib/
 logs/
+target/
 *.jar
 pom.xml
 .lein-deps-sum
+.lein-repl-history
+*~
+*.swp

--- a/conf/clusters.yaml
+++ b/conf/clusters.yaml
@@ -14,3 +14,5 @@ supervisor.hardware: "m1.large"
 zookeeper.count: 1
 zookeeper.image: "us-east-1/ami-d726abbe"         #64-bit ubuntu
 zookeeper.hardware: "m1.large"
+
+newrelic.licensekey: my_forty_character_new_relic_license_key

--- a/src/clj/backtype/storm/crate/newrelic.clj
+++ b/src/clj/backtype/storm/crate/newrelic.clj
@@ -1,0 +1,39 @@
+(ns backtype.storm.crate.newrelic
+  (:require
+   [pallet.resource.remote-file :as remote-file]
+   [pallet.compute :as compute]
+   [pallet.session :as session]
+   [pallet.action.exec-script :as exec-script]))
+
+(defn debfile [request]
+  (if (compute/is-64bit? (session/target-node request))
+      "newrelic-sysmond_1.2.0.257_amd64.deb"
+      "newrelic-sysmond_1.2.0.257_i386.deb"))
+
+(defn download-url [request]
+  (str "http://download.newrelic.com/debian/dists/newrelic/non-free/binary-" 
+       (if (compute/is-64bit? (session/target-node request))
+           "amd64/"
+           "i386/")
+       (debfile request)))
+
+(defn install [request]
+  (let [newrelicpkg (debfile request)]
+    (-> request
+        (remote-file/remote-file
+         (str "/home/storm/" newrelicpkg)
+         :url (download-url request)
+         :owner "storm"
+         :mode 644)
+        (exec-script/exec-script
+         (sudo dpkg -i ~newrelicpkg)))))
+
+(defn configure [request license-key]
+  (-> request
+      (exec-script/exec-script
+        ~(str "sudo nrsysmond-config --set license_key=" license-key))))
+
+(defn init [request]
+  (-> request
+      (exec-script/exec-script
+        ("sudo /etc/init.d/newrelic-sysmond start"))))

--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -8,6 +8,7 @@
    [backtype.storm.crate.leiningen :as leiningen]
    [backtype.storm.crate.zeromq :as zeromq]
    [backtype.storm.crate.ganglia :as ganglia]
+   [backtype.storm.crate.newrelic :as newrelic]
 
    [pallet.crate.git :as git]
    [pallet.crate.maven :as maven]
@@ -67,7 +68,10 @@
                                   (:username *USER*)
                                   (:public-key-path *USER*)))
             :configure (phase-fn
-                        (java/java :openjdk))}))
+                         (java/java :openjdk)
+                         (newrelic/install)
+                         (newrelic/configure (clusters-conf "newrelic.licensekey"))
+                         (newrelic/init))}))
 
 (defn zookeeper-server-spec []
      (server-spec


### PR DESCRIPTION
This adds support for New Relic server monitoring across all cluster nodes. Although this is implemented such that it always installs New Relic, so long as the license key is not valid it won't actually run.

Arguably this should be implemented by creating a generic New Relic crate that is then used by storm-deploy and I'm working on that solution, but want to hold off until pallet 0.8 is stable and we can move storm-deploy to pallet 0.8 so that this New Relic crate I'm working on will be generally useful.

In the meantime, this gets the job done.
