### PR TITLE
Strengthen security groups

### DIFF
--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -156,7 +156,8 @@
      (group-spec
       (str "zookeeper-" name)
       :node-spec (node-spec-from-config "zookeeper"
-                                        [(storm-conf "storm.zookeeper.port")])
+                                        ;[(storm-conf "storm.zookeeper.port")])
+                                        [])
       :extends server-spec))
   ([name]
      (zookeeper name (zookeeper-server-spec))
@@ -166,7 +167,8 @@
   (group-spec
     (nimbus-name name)
     :node-spec (node-spec-from-config "nimbus"
-                                      [(storm-conf "nimbus.thrift.port")])
+                                      ;[(storm-conf "nimbus.thrift.port")])
+                                      [])
     :extends server-spec))
 
 (defn nimbus [name release]
@@ -176,7 +178,8 @@
   (group-spec
     (str "supervisor-" name)
     :node-spec (node-spec-from-config "supervisor"
-                                    (storm-conf "supervisor.slots.ports"))
+                                    ;(storm-conf "supervisor.slots.ports"))
+                                    [])
     :extends server-spec))
 
 (defn supervisor [name release]

--- a/src/clj/backtype/storm/provision.clj
+++ b/src/clj/backtype/storm/provision.clj
@@ -48,8 +48,8 @@
 
 (defn sync-storm-conf-dir [aws name]
   (let [conf-dir (str (System/getProperty "user.home") "/.storm")
-        storm-yaml (storm/mk-storm-yaml name node/storm-yaml-path aws)
-        supervisor-yaml (storm/mk-supervisor-yaml aws name)]
+        storm-yaml (storm/mk-storm-yaml name node/storm-yaml-path aws :on-server false)
+        supervisor-yaml (storm/mk-supervisor-yaml aws name :on-server false)]
     (.mkdirs (File. conf-dir))
     (spit (str conf-dir "/storm.yaml") storm-yaml)
     (spit (str conf-dir "/supervisor.yaml") supervisor-yaml)))

--- a/src/clj/backtype/storm/security.clj
+++ b/src/clj/backtype/storm/security.clj
@@ -75,6 +75,15 @@
    :else (throw (IllegalArgumentException.
                  (str "Can't obtain IP protocol from argument of type " (type v))))))
 
+(def my-ip
+  (memoize
+    (fn []
+      (let [is (DataInputStream. (.openStream (URL. "http://whatismyip.akamai.com/")))
+            ret (.readLine is)]
+        (.close is)
+        ret
+        ))))
+
 (defn authorize
   "Adds permissions to a security group.
 
@@ -89,15 +98,6 @@
        (sg-service compute) (ebs/get-region region) (.getName group) (get-protocol protocol) from-port to-port (or ip-range "0.0.0.0/0"))
       (throw (IllegalArgumentException.
               (str "Can't find security group for name " group-name region ip-range from-port to-port))))))
-
-(def my-ip
-  (memoize
-    (fn []
-      (let [is (DataInputStream. (.openStream (URL. "http://whatismyip.akamai.com/")))
-            ret (.readLine is)]
-        (.close is)
-        ret
-        ))))
 
 (defn authorizeme [compute group-name port region]
   (try


### PR DESCRIPTION
This locks down the security groups with tighter restrictions and removes all ports that were previously open to the outside world.

Note that without these changes and without manually editing security groups in ec2, storm-deploy is dangerous in that it publicly reveals aws credentials in the web interface over 8080 to the world.
