### PR TITLE
Fix for #39.

### DIFF
--- a/src/clj/backtype/storm/provision.clj
+++ b/src/clj/backtype/storm/provision.clj
@@ -22,11 +22,7 @@
   )
 
 (defn jclouds-group [& group-pieces]
-  (str "jclouds#"
-       (apply str group-pieces)
-       "#"
-       (my-region)
-       ))
+  (str "jclouds#" (apply str group-pieces)))
 
 (defn- print-ips-for-tag! [aws tag-str]
   (let [running-node (filter running? (map (partial pallet.compute.jclouds/jclouds-node->node aws) (nodes-in-group aws tag-str)))]


### PR DESCRIPTION
I think that the upgrade from jClouds 1.4.2 to 1.5.1 in the previous
commit (9d6e47b7) made a change in how `.createSecurityGroupInRegion`
works (see security.clj).
