### PR TITLE
Fix for storm-deploy failing - prepare daemon dies wrt log4j

### DIFF
--- a/src/clj/backtype/storm/crate/storm.clj
+++ b/src/clj/backtype/storm/crate/storm.clj
@@ -97,6 +97,7 @@
      (ln "-s $HOME/`ls | grep zip | sed s/.zip//` storm")
 
      (mkdir -p "daemon")
+     (mkdir -p "$HOME/storm/log4j")
      (chmod "755" "$HOME/storm/log4j")
      (touch "$HOME/storm/log4j/storm.log.properties")
      (touch "$HOME/storm/log4j/log4j.properties")


### PR DESCRIPTION
Added missing `$HOME/storm/log4j` directory as per fix provided by @dixon1e.
https://groups.google.com/forum/#!msg/storm-user/d_K5yWVmVvY/uXwa_LGei3MJ
