### PR TITLE
Updated leiningen to 2.3.2 from 1.5.2

### DIFF
--- a/src/clj/backtype/storm/crate/leiningen.clj
+++ b/src/clj/backtype/storm/crate/leiningen.clj
@@ -3,8 +3,8 @@
    [pallet.resource.remote-file :as remote-file]
    [pallet.action.exec-script :as exec-script]))
 
-;; this is 1.5.2. freezing version to ensure deploy is stable
-(def download-url "https://raw.github.com/technomancy/leiningen/a1fa43400295d57a9acfed10735c1235904a9407/bin/lein")
+;; this is 2.3.2. freezing version to ensure deploy is stable 
+(def download-url "https://raw.github.com/technomancy/leiningen/7d7426b14326fc5257d82d97c314e2ea8455597e/bin/lein")
 
 (defn install [request]
   (-> request


### PR DESCRIPTION
Still using a frozen version for stability.
An alternative to using a frozen version would be to use the latest stable release: https://raw.github.com/technomancy/leiningen/stable/bin/lein
