### PR TITLE
Allows storm-deploy more flexibility - checkout branches and SHA1s

### DIFF
--- a/src/clj/backtype/storm/crate/leiningen.clj
+++ b/src/clj/backtype/storm/crate/leiningen.clj
@@ -4,7 +4,9 @@
    [pallet.action.exec-script :as exec-script]))
 
 ;; this is 1.5.2. freezing version to ensure deploy is stable
-(def download-url "https://raw.github.com/technomancy/leiningen/a1fa43400295d57a9acfed10735c1235904a9407/bin/lein")
+;; (def download-url "https://raw.github.com/technomancy/leiningen/a1fa43400295d57a9acfed10735c1235904a9407/bin/lein")
+;; this is 2.3.2. freezing version to ensure deploy is stable 
+(def download-url "https://raw.github.com/technomancy/leiningen/7d7426b14326fc5257d82d97c314e2ea8455597e/bin/lein")
 
 (defn install [request]
   (-> request

--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -28,11 +28,11 @@
    [org.jclouds.compute2 :only [nodes-in-group]]
    [clojure.walk]))
 
-(defn parse-release [release]
-  (map #(Integer/parseInt %) (.split release "\\.")))
+(defn parse-branch [branch]
+  (map #(Integer/parseInt %) (.split branch "\\.")))
 
-(defn release> [release1 release2]
-  (->> (map - (parse-release release1) (parse-release release2))
+(defn branch> [branch1 branch2]
+  (->> (map - (parse-branch branch1) (parse-branch branch2))
        (take-while #(>= % 0))
        (some pos?)))
 
@@ -93,41 +93,41 @@
                       (storm/exec-daemon)
                       (ganglia/ganglia-finish))}))
 
-(defn supervisor-server-spec [name release]
+(defn supervisor-server-spec [name branch commit]
      (server-spec
       :extends (storm-base-server-spec name)
       :phases {:configure (phase-fn
                            (ganglia/ganglia-node (nimbus-name name))
                            (storm/install-supervisor
-                            release
+                            branch commit
                             "/mnt/storm"))
                :post-configure (phase-fn
                                 (ganglia/ganglia-finish)
                                 (storm/write-storm-exec
                                  "supervisor"))}))
 
-(defn maybe-install-drpc [req release]
-  (if (or (not release) (release> release "0.5.3"))
+(defn maybe-install-drpc [req branch]
+  (if (or (not branch) (= branch "master") (branch> branch "0.5.3"))
     (storm/install-drpc req)
     req
     ))
 
-(defn maybe-exec-drpc [req release]
-  (if (or (not release) (release> release "0.5.3"))
+(defn maybe-exec-drpc [req branch]
+  (if (or (not branch) (= branch "master") (branch> branch "0.5.3"))
     (storm/exec-drpc req)
     req
     ))
 
-(defn nimbus-server-spec [name release]
+(defn nimbus-server-spec [name branch commit]
      (server-spec
       :extends (storm-base-server-spec name)
       :phases {:configure (phase-fn
                            (ganglia/ganglia-master (nimbus-name name))
                            (storm/install-nimbus
-                            release
+                            branch commit
                             "/mnt/storm")
                            (storm/install-ui)
-                           (maybe-install-drpc release))
+                           (maybe-install-drpc branch))
                :post-configure (phase-fn
                                 (ganglia/ganglia-finish)
                                 (storm/write-storm-exec
@@ -135,7 +135,7 @@
                                  )
                :exec (phase-fn
                         (storm/exec-ui)
-                        (maybe-exec-drpc release))}))
+                        (maybe-exec-drpc branch))}))
 
 (defn node-spec-from-config [group-name inbound-ports]
   (letfn [(assoc-with-conf-key [image image-key conf-key & {:keys [f] :or {f identity}}]
@@ -169,8 +169,8 @@
                                       [(storm-conf "nimbus.thrift.port")])
     :extends server-spec))
 
-(defn nimbus [name release]
-  (nimbus* name (nimbus-server-spec name release)))
+(defn nimbus [name branch commit]
+  (nimbus* name (nimbus-server-spec name branch commit)))
 
 (defn supervisor* [name server-spec]
   (group-spec
@@ -179,7 +179,7 @@
                                     (storm-conf "supervisor.slots.ports"))
     :extends server-spec))
 
-(defn supervisor [name release]
-  (supervisor* name (supervisor-server-spec name release)))
+(defn supervisor [name branch commit]
+  (supervisor* name (supervisor-server-spec name branch commit)))
 
 

--- a/src/clj/backtype/storm/provision.clj
+++ b/src/clj/backtype/storm/provision.clj
@@ -22,11 +22,7 @@
   )
 
 (defn jclouds-group [& group-pieces]
-  (str "jclouds#"
-       (apply str group-pieces)
-       "#"
-       (my-region)
-       ))
+  (str "jclouds#" (apply str group-pieces)))
 
 (defn- print-ips-for-tag! [aws tag-str]
   (let [running-node (filter running? (map (partial pallet.compute.jclouds/jclouds-node->node aws) (nodes-in-group aws tag-str)))]


### PR DESCRIPTION
The storm `--release` model is very unclear and not all that useful. Currently there is a choice of passing a no release, in which case you get a version of storm based on the latest commit from master or you get to pass a release which gets you the latest commit from that branch, e.g.,

```
lein deploy-storm --start --name mycluster --release 0.9.0
```

gets you storm 0.9.0wip16 (roughly, actually it gets you commit (d12c33543c9b2e8c8e35908f8672fa06edd18c2e, which is between 0.9.0-wip16 and 0.9.0-wip17)

and 

```
lein deploy-storm --start --name mycluster
```

gets you the latest commit from master. It's not possible to get anything inbetween.

This commit drops the `--release` argument in favour of a `--branch` argument (equivalent to `--release`) and a `--commit` argument, which takes a SHA1. If a commit is passed then we attempt to checkout that SHA1 into a new branch and use that. This gives us much more flexibility, e.g., to checkout storm 0.9.0-rc2 you would run

```
    lein deploy-storm --start --name mycluster --branch master --commit 32098d5b2694434ea43d430a4703fbe51bab268f 
```

If you want the latest version from a specific branch (say 0.8.3) you can execute 

```
    lein deploy-storm --start --name mycluster --branch 0.8.3
```

and if you want the bleeding edge you can still execute this get the latest commit from master

```
    lein deploy-storm --start --name mycluster
```

The diff on this commit is bigger than it might have been because i deliberately changed `release` to `branch` wherever possible. I think now that storm has both releases (since 0.9.9-rc1) and branches we should make the code closer to what's actually happening (i.e., checking out branches rather than releases).

I'd love to get feedback on this. I've played around with it today but I wouldn't go so far to say it's perfect. I'd like to see if anyone else has had success with it before pulling it into nathanmarz/storm-deploy proper.

This includes @xpe's pull request nathanmarz/storm-deploy#40 and @lorcan's pull requests nathanmarz/storm-deploy#43 and nathanmarz/storm-deploy#44
