### PR TITLE
BugFix: --branch was being ignored in storm-deploy due to typo

### DIFF
--- a/src/clj/backtype/storm/crate/storm.clj
+++ b/src/clj/backtype/storm/crate/storm.clj
@@ -66,7 +66,7 @@
         (cd "$HOME/build")
 
         (when-not (directory? "storm")
-          (git clone -b branch ~url ))
+          (git clone -b ~branch ~url ))
 
         (cd storm)
         (git pull)


### PR DESCRIPTION
Value of variable `branch` was not being used, rather git was searching
for the branch called "branch". 
This issue was first raised by Christopher Cantrell on the storm-user mailing list [here](https://groups.google.com/forum/#!topic/storm-user/dcvViDujC-E)
