### PR TITLE
lein1 is used for deploying storm <0.9.0, otherwise lein2 is used.

### DIFF
--- a/src/clj/backtype/storm/branch.clj
+++ b/src/clj/backtype/storm/branch.clj
@@ -1,0 +1,9 @@
+(ns backtype.storm.branch)
+
+(defn parse-branch [branch]
+  (map #(Integer/parseInt %) (.split branch "\\.")))
+
+(defn branch> [branch1 branch2]
+  (->> (map - (parse-branch branch1) (parse-branch branch2))
+       (take-while #(>= % 0))
+       (some pos?)))

--- a/src/clj/backtype/storm/crate/leiningen.clj
+++ b/src/clj/backtype/storm/crate/leiningen.clj
@@ -4,12 +4,13 @@
    [pallet.action.exec-script :as exec-script]))
 
 ;; this is 1.5.2. freezing version to ensure deploy is stable
-;; (def download-url "https://raw.github.com/technomancy/leiningen/a1fa43400295d57a9acfed10735c1235904a9407/bin/lein")
+(def download-lein1-url "https://raw.github.com/technomancy/leiningen/a1fa43400295d57a9acfed10735c1235904a9407/bin/lein")
 ;; this is 2.3.2. freezing version to ensure deploy is stable 
-(def download-url "https://raw.github.com/technomancy/leiningen/7d7426b14326fc5257d82d97c314e2ea8455597e/bin/lein")
+(def download-lein2-url "https://raw.github.com/technomancy/leiningen/7d7426b14326fc5257d82d97c314e2ea8455597e/bin/lein")
 
-(defn install [request]
-  (-> request
+(defn install [request version]
+  (let [download-url (if (= version 1) download-lein1-url download-lein2-url)]
+    (-> request
       (remote-file/remote-file
        "/usr/local/bin/lein"
        :url download-url
@@ -17,4 +18,4 @@
        :mode 755)
       (exec-script/exec-script
        (export "LEIN_ROOT=1")
-       ("/usr/local/bin/lein"))))
+       ("/usr/local/bin/lein")))))

--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -23,18 +23,11 @@
    [pallet.resource.exec-script :as exec-script])
   (:use
    [backtype.storm config]
+   [backtype.storm.branch :only [branch>]]
    [pallet compute core resource phase]
    [pallet [utils :only [make-user]]]
    [org.jclouds.compute2 :only [nodes-in-group]]
    [clojure.walk]))
-
-(defn parse-branch [branch]
-  (map #(Integer/parseInt %) (.split branch "\\.")))
-
-(defn branch> [branch1 branch2]
-  (->> (map - (parse-branch branch1) (parse-branch branch2))
-       (take-while #(>= % 0))
-       (some pos?)))
 
 ;; CONSTANTS
 


### PR DESCRIPTION
Addresses a bug identified by [Ryan Ebanks on the mailing list](https://groups.google.com/forum/#!topic/storm-user/5qOUkMfXkj4). The storm-deploy process was dying because earlier versions of storm were expecting lein1 (e.g., [0.8.2](https://github.com/nathanmarz/storm/blob/0.8.2/project.clj#L2-L4)) and storm-deploy was defaulting to lein2 regardless of storm version. This fix makes lein1 a dependency if using pre 0.9.0 storm and lein2 otherwise.
