### PR TITLE
Updated zookeeper to latest stable (3.3.6)

### DIFF
--- a/src/clj/backtype/storm/crate/zookeeper.clj
+++ b/src/clj/backtype/storm/crate/zookeeper.clj
@@ -46,7 +46,7 @@
   [session & {:keys [user group version home]
               :or {user zookeeper-user
                    group zookeeper-group
-                   version "3.3.5"}
+                   version "3.3.6"}
               :as options}]
   (let [url (url version)
         home (or home (format "%s-%s" install-path version))]

--- a/src/clj/backtype/storm/node.clj
+++ b/src/clj/backtype/storm/node.clj
@@ -66,7 +66,7 @@
      (server-spec
       :extends (base-server-spec)
       :phases {:configure (phase-fn
-                           (zookeeper/install :version "3.3.5")
+                           (zookeeper/install :version "3.3.6")
                            (zookeeper/configure
                             :clientPort (storm-conf "storm.zookeeper.port")
                             :maxClientCnxns 0)


### PR DESCRIPTION
The specified zookeeper version must be available here:
http://www.apache.org/dist/zookeeper/
However 3.3.5 is no longer available from there, which causes a
deployment failure. This problem was [first highlighted by Lorin
Kobashigawa on the storm-user mailing
list](https://groups.google.com/d/msg/storm-user/i0x3WFgW36k/dd5vufPkFj4
J).
